### PR TITLE
Add ci config to build on GitHub and add some minor fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build plugin
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build plugin
+        run: ./gradlew build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Plugin
+          path: build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ tasks.build {
 }
 
 processResources {
-    def props = [version: version]
+    def props = [version: version, kotlinVersion: kotlinVersion]
     inputs.properties props
     filteringCharset 'UTF-8'
     filesMatching('plugin.yml') {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,4 +5,4 @@ main: io.github.teneko.daytimeadjuster.DayTimeAdjusterPlugin
 api-version: 1.20
 
 libraries:
-  - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20
+  - org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,8 @@
 name: day-time-adjuster
+author: Teneko
 version: '${version}'
 main: io.github.teneko.daytimeadjuster.DayTimeAdjusterPlugin
 api-version: 1.20
+
+libraries:
+  - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.20


### PR DESCRIPTION
 - Will now build the plugin on each commit
 - Added `libraries` section to `plugin.yml`. Newer spigot versions can use this to automatically pull a maven library before enabling the plugin, removing the need to include the library or depend on another plugin which includes it for us
 - Added you as author to `plugin.yml`